### PR TITLE
Incorporate Arena's comments; add further text

### DIFF
--- a/sections/3-2-work_plan.md
+++ b/sections/3-2-work_plan.md
@@ -21,18 +21,19 @@ The working group will address the question of “How we can predict raptor resp
 
 _Tuesday, May 9th, 2023_
 
-Each group will make a quick presentation of their work done the previous day, and then discuss and make a final proposal containing the main hypothesis, model, and preliminary data analysis.
+During the morning each group will work on finishng their tasks and during the afternoon groups will be shuffled  and make a quick presentation of their work done, to discuss and collect multidivertse feedback to draft a final proposal of their particular tasks.
 
 _Wednesday, May 10th, 2023_
 
-The working group will finalize the proposal and an outline that establishes the meta-analysis strategy and the team roles and accountability.
-Afternon break/retreat, hopefully to see the raptors. 
+The working groups will finalize their tasks and present their progress during the morning, they will recive target feedback to have an amalgamation of ideas and identification of missing pieces. Finally, there will be an afternon retreat with the hope to see the raptors.
 
 _Thursday, May 11th, 2023_
 
-The working group will discuss the future directions of the living data project and assign leadership roles to accomplish every single left task.
-A detailed plan schedule will be created that establishes a critical route plan to achieve the goal outcomes. including meetings and zoom follow-ups.
+work at  in breakout groups (perhaps larger groups of 5 this time?)
+Lareger working groups will be fomred (5 individuals) to assign leadership roles to accomplish every single left task and discuss and solve the remaining unsolved parts of the assaingments.  
 
 _Friday, May 12th, 2023_
+
+The final progress will be presented to then discuss the rough manuscript structure and  talk about future directions of the living data project and stablish a detailed plan schedule will be created that establishes a critical route plan to achieve the goal outcomes, including meetings and zoom follow-ups. 
 
 **Follow-up activities and milestones**

--- a/sections/3-2-work_plan.md
+++ b/sections/3-2-work_plan.md
@@ -14,10 +14,8 @@ In early 2023, the organizers will collect and tidy all database components. Thi
 
 _Monday, May 8th, 2023_
 
-In the morning, working group participants will present their short talks and field questions from their peers. These presentations will be requested and described in the pre-working-group meeting, in early April. Refreshments and snacks will be provided during this session.  
-After all participants have presented, the organizers will end the morning session with a joint presentation. All organizers will describe the topic and goals of the working group, and a code of conduct will be established for the optimal run of the diverse,
-the equitable, and inclusive working group, including a discussion on how we will use and handle the data coming from underrepresented areas and collaborators.
-The working group will address the question of “How we can predict raptor responses to climate change in the prairies and their responses to ecosystem restoration?”, by brainstorming solution ideas in the frame of their area of expertise. Breakout groups will be formed to propose a hypothesis and test model approaches.
+Working group participants will present their short talks and field questions in the morning. The organizers will end the morning session with a joint presentation. All organizers will describe the topic and goals of the working group, and a code of conduct will be established for the optimal run of the diverse, equitable, and inclusive working group, including a discussion on how we will use and handle the data coming from underrepresented areas and collaborators.
+Finally, the working group will address the question of “How we can predict raptor responses to climate change in the prairies and their responses to ecosystem restoration?”, by brainstorming solution ideas in the frame of their area of expertise. Teams will be formed to focus on specific tasks taking advantage of their expertise.
 
 _Tuesday, May 9th, 2023_
 

--- a/sections/3-2-work_plan.md
+++ b/sections/3-2-work_plan.md
@@ -14,10 +14,25 @@ In early 2023, the organizers will collect and tidy all database components. Thi
 
 _Monday, May 8th, 2023_
 
+In the morning, working group participants will present their short talks and field questions from their peers. These presentations will be requested and described in the pre-working-group meeting, in early April. Refreshments and snacks will be provided during this session.  
+After all participants have presented, the organizers will end the morning session with a joint presentation. All organizers will describe the topic and goals of the working group, and a code of conduct will be established for the optimal run of the diverse,
+the equitable, and inclusive working group, including a discussion on how we will use and handle the data coming from underrepresented areas and collaborators.
+The working group will address the question of “How we can predict raptor responses to climate change in the prairies and their responses to ecosystem restoration?”, by brainstorming solution ideas in the frame of their area of expertise. Breakout groups will be formed to propose a hypothesis and test model approaches.
+
 _Tuesday, May 9th, 2023_
+
+Each group will make a quick presentation of their work done the previous day, and then discuss and make a final proposal containing the main hypothesis, model, and preliminary data analysis.
 
 _Wednesday, May 10th, 2023_
 
+The working group will finalize the proposal and an outline that establishes the meta-analysis strategy and the team roles and accountability.
+Afternon break/retreat, hopefully to see the raptors. 
+
 _Thursday, May 11th, 2023_
 
+The working group will discuss the future directions of the living data project and assign leadership roles to accomplish every single left task.
+A detailed plan schedule will be created that establishes a critical route plan to achieve the goal outcomes. including meetings and zoom follow-ups.
+
 _Friday, May 12th, 2023_
+
+**Follow-up activities and milestones**


### PR DESCRIPTION
We will need to consult with the others tomorrow on some aspects of the work plan; for example, I am unsure if we will need to have separate breakout groups developing independent hypotheses/models, or if each breakout group should have a focused task that relates to the same central hypothesis. 

We will also have an extra day to account for in the work plan. I propose we could roughly do the following, what do you think? 
Monday: presentations in morning, then meet groups (groups of 3-4?), and begin work on task
Tuesday: breakout groups work on respective tasks/hypotheses, and in afternoon, the breakout groups are shuffled
Wednesday: presentation of progress in morning, amalgamation of ideas and identification of missing pieces, then retreat in afternoon
Thursday: work at the remaining pieces in breakout groups (perhaps larger groups of 5 this time?) 
Friday: final presentations of progress, discussions on rough manuscript structure, and a description of follow-up plans and outcomes (as you had suggested for Thursday)